### PR TITLE
Don't try to load RSpec 1 support just because some completely unrelated...

### DIFF
--- a/lib/rspec/given.rb
+++ b/lib/rspec/given.rb
@@ -1,4 +1,4 @@
-if defined? Spec
+if !defined?(RSpec) && defined?(Spec::Version::STRING) && Spec::Version::STRING =~ /^1\./
   require 'rspec/given/rspec1_given'
 else
   require 'rspec/given/version'


### PR DESCRIPTION
... thing happens to define a top-level constant named "Spec" (i.e. the TeamCity RSpec output formatter).
