### PR TITLE
This makes Bundler happy

### DIFF
--- a/lib/rspec-given.rb
+++ b/lib/rspec-given.rb
@@ -1,0 +1,1 @@
+require 'rspec/given'


### PR DESCRIPTION
Bundler for a rails project does some magic to require all the gems for the given environment. Without some help, bundler doesn't know what to do. By default, it looks like bundler is just doing a require on the gem name. By adding this dummy file to the project to require the real files, bundler is happier.

The real problem here is that new people to rspec-given have a problem getting it to work with the default setup. You have to add 

``` ruby
  gem "rspec-given", :require => "rspec/given"
```
