### PR TITLE
rspec-given is never explicitly requiring rspec

### DIFF
--- a/lib/rspec/given/configure.rb
+++ b/lib/rspec/given/configure.rb
@@ -1,3 +1,4 @@
+require 'rspec'
 require 'rspec/given/extensions'
 
 RSpec.configure do |c|


### PR DESCRIPTION
My goal is to have

``` ruby
  gem "rspec-given"
```

in my Gemfile and use Rails/Bundler to load the gems into the correct environment. Maybe that's not a good idea, but I like it.  Right now my :test environment has:

``` ruby
group :test do
  gem "rspec-rails"
  gem "rspec-given"
  gem 'cucumber-rails'
  gem 'database_cleaner'
  gem 'launchy'
  gem 'email_spec'
end
```

When I run cucumber, I get this error:

```
undefined method `configure' for RSpec:Module (NoMethodError)
/Users/dalcorn/devel/horse-show-bill/vendor/ruby/1.9.1/gems/rspec-given-1.5.0/lib/rspec/given/configure.rb:3:in `<top (required)>'
...
/Users/dalcorn/devel/horse-show-bill/vendor/ruby/1.9.1/gems/rspec-given-1.5.0/lib/rspec/given.rb:17:in `<top (required)>'
```

This patch fixes that. However, I can also fix this problem by putting 

```
  gem "rspec-given", :require => false
```

and then require "rspec/given" in my spec_helper.rb. I don't know if this is the right way to fix this or not. But I feel generating the pull request and then including @dchelimsky in the discussion
