### PR TITLE
Updated README.md to fix travis-ci link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Master |
 | :----: |
-| [![Master Build Status](https://secure.travis-ci.org/jimweirich/rspec-given.png?branch=master)](https://secure.travis-ci.org/jimweirich/rspec-given) |
+| [![Master Build Status](https://secure.travis-ci.org/jimweirich/rspec-given.png?branch=master)](https://travis-ci.org/jimweirich/rspec-given) |
 
 Covering rspec-given, version 2.4.0.
 


### PR DESCRIPTION
The old travis-ci link at the top of the README did not direct directly to the rspec-given page in travis-ci.org.

The old link led to a blank page.
