### PR TITLE
Add optional description string to Then clause

### DIFF
--- a/lib/rspec/given/extensions.rb
+++ b/lib/rspec/given/extensions.rb
@@ -228,11 +228,12 @@ module RSpec
       #
       # :call-seq:
       #   Then { ... assertion ... }
+      #   Then("description") { ... assertion ... }
       #
-      def Then(&block)
+      def Then(description=nil, &block)
         env = block.binding
         file, line = eval "[__FILE__, __LINE__]", env
-        description = _rgc_lines.line(file, line) unless RSpec::Given.source_caching_disabled
+        description ||= _rgc_lines.line(file, line) unless RSpec::Given.source_caching_disabled
         if description
           cmd = "it(description)"
         else


### PR DESCRIPTION
Hi, here's a small patch to allow explicitly specifying a description for a Then clause.  Potentially useful for cases where the source code itself isn't particularly clear or compact for a report.

e.g.

```
Then("Widget form has a highlighted Undo button") {
   page.should have_selector("#Widget form button.active",  :text => "Undo")
}
```
