### PR TITLE
Use "with" rather than "when" to name a context that defines a Given

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ describe Stack do
   Given(:stack) { stack_with(initial_contents) }
   Invariant { stack.empty?.should == (stack.depth == 0) }
 
-  context "when empty" do
+  context "with no items" do
     Given(:initial_contents) { [] }
     Then { stack.depth.should == 0 }
 


### PR DESCRIPTION
Hi.  Looks like your sample code generally uses "with" to describe contexts that contain Givens, and "when" to describe contexts that contain "when".  But there was one case of a Given context that was described with "when".  

To minimize (my own) confusion regarding Givens vs Whens I figured I'd change it to use a "with" for that context as well.
