### PR TITLE
Add installation section to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,34 @@ RSpec specifications.
 
 rspec-given is ready for production use.
 
+## Installation
+
+### If you are using bundler
+
+Add `rspec-given` to the `:test` group in the `Gemfile`:
+
+```ruby
+group :test do
+  gem 'rspec-given'
+end
+```
+
+Download and install:
+
+`$ bundle`
+
+Then just require `rspec/given` in the `spec_helper` of your project and it is
+ready to go.
+
+### If you are not using bundler
+
+Install the gem:
+
+`$ gem install rspec-given`
+
+Then just require `rspec/given` in the `spec_helper` of your project and it is
+ready to go.
+
 ## Example
 
 Here is a specification written in the rspec-given framework:
@@ -618,9 +646,6 @@ Chaffee](http://rubygems.org/profiles/alexch) and [Steve
 Conover](http://rubygems.org/profiles/sconoversf).
 
 ## Configuration
-
-Just require 'rspec/given' in the spec helper of your project and it
-is ready to go.
 
 If the RSpec format option document, html or textmate is chosen,
 RSpec/Given will automatically add additional source code information to


### PR DESCRIPTION
Hello!

I though that would be great if the README could have an installation section even in this case that is very simple.

The installation section remove any possible doubt.

I put in the top of the README because is there where the most part of the gem's READMEs are, so it is the first place we focus our eyes when we are looking for it.

What do you thing guys?
