### PR TITLE
Bug fix for `have_failed` with RSpec 3.0.0

### DIFF
--- a/lib/given/rspec/have_failed_212.rb
+++ b/lib/given/rspec/have_failed_212.rb
@@ -7,7 +7,7 @@ module RSpec
       class HaveFailedMatcher < RSpec::Matchers::BuiltIn::RaiseError
         def matches?(given_proc, negative_expectation = false)
           if given_proc.is_a?(::Given::Failure)
-            super
+            super(lambda { given_proc.call }, negative_expectation)
           else
             super(lambda { }, negative_expectation)
           end
@@ -15,7 +15,7 @@ module RSpec
 
         def does_not_match?(given_proc)
           if given_proc.is_a?(::Given::Failure)
-            super(given_proc)
+            super(lambda { given_proc.call })
           else
             super(lambda { })
           end


### PR DESCRIPTION
With Mr. Weirich sadly no longer with us, I don't know who if anyone wil be maintaing this, but I figure I may as well at least post the issue/PR in case anybody else comes across the same issue.

With the release of RSpec 3.0.0, the `have_failed` mechanism no longer works.  Attempting:

```
  When(:result) { stack.pop }
  Then { expect(result).to have_failed(UnderflowError, /empty/) }
```

Results in an error like:

```
 Failure/Error: Then { expect(credentials).to have_failed UnderflowError }
    expected UnderFlowError but was not given a block
```

This PR should fix that.

(The specific RSpec change that caused this to break was rspec/rspec-expections@79582c2, which cleaned up the delineation between blocks and values for expect { } vs expect() as per rspec/rspec-expectations#526 ; unfortunately rspec-given was relying on the previous looseness to be able to use a value that quacked like a Proc.)
