### PR TITLE
Add support for rspec 3

### DIFF
--- a/lib/given/rspec/have_failed_212.rb
+++ b/lib/given/rspec/have_failed_212.rb
@@ -15,7 +15,7 @@ module RSpec
 
         def does_not_match?(given_proc)
           if given_proc.is_a?(::Given::Failure)
-            super(lambda { given_proc.call })
+            super(given_proc)
           else
             super(lambda { })
           end

--- a/lib/given/rspec/have_failed_212.rb
+++ b/lib/given/rspec/have_failed_212.rb
@@ -7,7 +7,7 @@ module RSpec
       class HaveFailedMatcher < RSpec::Matchers::BuiltIn::RaiseError
         def matches?(given_proc, negative_expectation = false)
           if given_proc.is_a?(::Given::Failure)
-            super
+            super(lambda { given_proc.call }, negative_expectation)
           else
             super(lambda { }, negative_expectation)
           end
@@ -15,7 +15,7 @@ module RSpec
 
         def does_not_match?(given_proc)
           if given_proc.is_a?(::Given::Failure)
-            super(given_proc)
+            super(lambda { given_proc.call })
           else
             super(lambda { })
           end

--- a/spec/lib/given/failure_spec.rb
+++ b/spec/lib/given/failure_spec.rb
@@ -21,9 +21,9 @@ describe Given::Failure do
   end
 
   describe "raising error" do
-    Then { expect(failure).to raise_error(StandardError, "Oops") }
-    Then { expect(failure).to raise_error(StandardError) }
-    Then { expect(failure).to raise_error }
+    Then { expect { failure.call }.to raise_error(StandardError, "Oops") }
+    Then { expect { failure.call }.to raise_error(StandardError) }
+    Then { expect { failure.call }.to raise_error }
   end
 
   describe "== have_failed" do

--- a/spec/lib/given/have_failed_spec.rb
+++ b/spec/lib/given/have_failed_spec.rb
@@ -9,7 +9,7 @@ module HaveFailedSpec
     context "with a failure" do
       When(:result) { fail CustomError, "Ouch" }
 
-      Then { expect(result).to raise_error(CustomError, "Ouch") }
+      Then { expect { result.call }.to raise_error(CustomError, "Ouch") }
       Then { expect(result).to have_failed(CustomError, "Ouch") }
       Then { expect(result).to have_raised(CustomError, "Ouch") }
 
@@ -23,10 +23,10 @@ module HaveFailedSpec
     context "with a standard failure" do
       When(:result) { fail "Ouch" }
 
-      Then { expect(result).to raise_error(StandardError, "Ouch") }
-      Then { expect(result).to raise_error(StandardError, /^O/) }
-      Then { expect(result).to raise_error(StandardError) }
-      Then { expect(result).to raise_error }
+      Then { expect { result.call }.to raise_error(StandardError, "Ouch") }
+      Then { expect { result.call }.to raise_error(StandardError, /^O/) }
+      Then { expect { result.call }.to raise_error(StandardError) }
+      Then { expect { result.call }.to raise_error }
 
       Then { expect(result).to have_failed(StandardError, "Ouch") }
       Then { expect(result).to have_failed(StandardError, /^O/) }


### PR DESCRIPTION
## This PR is mirrored on the [new repo here](https://github.com/rspec-given/rspec-given/pull/1)

There are currently 19 failing specs on master when running the latest versions of rspec. 
- [x] 9 specs fixed by @ronen's https://github.com/jimweirich/rspec-given/pull/43
- [x] 2 specs fixed by reverting the part of the above change (`does_not_match?` was inadvertently wrapping `Given::Failure` objects)
- [x] 8 specs fixed by passing `expect` a block when paired with the `raise_error` matcher

Before merging, it may make sense to attempt a travis build matrix that maintains rspec 2 support.
